### PR TITLE
Fallback to Django Session

### DIFF
--- a/jwt_auth/middleware.py
+++ b/jwt_auth/middleware.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.middleware import get_user
 from django.http import JsonResponse
 from django.utils.translation import ugettext as _
 from jwt_auth import settings as jwt_auth_settings, exceptions, mixins
@@ -30,6 +31,8 @@ class JWTAuthenticationMiddleware:
 
     def __call__(self, request):
         user = None
+        if hasattr(request, 'session'):
+          user = get_user(request)
         try:
             token = mixins.get_token_from_request(request)
             payload = mixins.get_payload_from_token(token)


### PR DESCRIPTION
Allow using `JWTAuthenticationMiddleware` along with `django.contrib.auth.middleware.AuthenticationMiddleware`
This update makes it possible to login into Django's admin interface.
For example, when using following middleware config:
```python
MIDDLEWARE = [
    'corsheaders.middleware.CorsMiddleware',
    'django.middleware.security.SecurityMiddleware',
    'django.contrib.sessions.middleware.SessionMiddleware',
    'django.middleware.common.CommonMiddleware',
    'django.middleware.csrf.CsrfViewMiddleware',
    'django.contrib.auth.middleware.AuthenticationMiddleware',
    'jwt_auth.middleware.JWTAuthenticationMiddleware' # won't allow to access django admin
]
```